### PR TITLE
Docs: clarify installation instruction in README.org

### DIFF
--- a/README.org
+++ b/README.org
@@ -32,7 +32,8 @@ Gain the modal superpowers of the dark side, without succumbing to evil!
 
 * Install
 Clone this repository into =.emacs.d/private/xah-fly-keys=, or where ever you
-keep your private layers.
+keep your private layers. Note that the name of the cloned repository will be 
+"xah-fly-keys-layer" and you should rename it to "xah-fly-keys".
 
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =xah-fly-keys= to the existing =dotspacemacs-configuration-layers= list in 


### PR DESCRIPTION
Fixes #1 : Just made a slight change which I think might avoid confusion (at least was the case for me).